### PR TITLE
Allow to change kubemark image (defaults to docker.io/gofed/kubemark:v1.11.3-6)

### DIFF
--- a/examples/machine-set-2a.yaml
+++ b/examples/machine-set-2a.yaml
@@ -21,6 +21,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/examples/machine-set-2b.yaml
+++ b/examples/machine-set-2b.yaml
@@ -21,6 +21,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/examples/machine-set-2c.yaml
+++ b/examples/machine-set-2c.yaml
@@ -21,6 +21,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/examples/machine-set.yaml
+++ b/examples/machine-set.yaml
@@ -21,6 +21,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/examples/machine.yaml
+++ b/examples/machine.yaml
@@ -13,6 +13,7 @@ spec:
       unhealthyDuration: 5s
       healthyDuration: 5s
       turnUnhealthyPeriodically: true
+      image: docker.io/gofed/kubemark:v1.11.3-6
   versions:
     kubelet: 1.10.1
     controlPlane: 1.10.1

--- a/examples/static-machine.yaml
+++ b/examples/static-machine.yaml
@@ -11,6 +11,7 @@ spec:
     value:
       apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
       kind: KubemarkMachineProviderConfig
+      image: docker.io/gofed/kubemark:v1.11.3-6
   versions:
     kubelet: 1.10.1
     controlPlane: 1.10.1

--- a/examples/worker-machinesets.yaml
+++ b/examples/worker-machinesets.yaml
@@ -21,6 +21,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1
@@ -47,6 +48,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1
@@ -73,6 +75,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
+          image: docker.io/gofed/kubemark:v1.11.3-6
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -237,6 +237,10 @@ func (a *Actuator) CreateMachine(cluster *machinev1.Cluster, machine *machinev1.
 		return nil, a.handleMachineError(machine, apierrors.InvalidMachineConfiguration("error decoding MachineProviderConfig: %v", err), createEventAction)
 	}
 
+	if machineProviderConfig.Image == "" {
+		return nil, a.handleMachineError(machine, apierrors.InvalidMachineConfiguration("KubemarkMachineProviderConfig.Image is missing"), createEventAction)
+	}
+
 	// We explicitly do NOT want to remove stopped masters.
 	if !isMaster(machine) {
 		// TODO(jchaloup): remove broken pods (whatever that means)
@@ -286,7 +290,7 @@ func (a *Actuator) CreateMachine(cluster *machinev1.Cluster, machine *machinev1.
 			Containers: []corev1.Container{
 				{
 					Name:  "hollow-kubelet",
-					Image: "docker.io/gofed/kubemark:v1.11.3-6",
+					Image: machineProviderConfig.Image,
 					Ports: []corev1.ContainerPort{
 						{ContainerPort: 4194},
 						{ContainerPort: 10250},
@@ -315,7 +319,7 @@ func (a *Actuator) CreateMachine(cluster *machinev1.Cluster, machine *machinev1.
 				},
 				{
 					Name:  "hollow-proxy",
-					Image: "docker.io/gofed/kubemark:v1.11.3-6",
+					Image: machineProviderConfig.Image,
 					Env: []corev1.EnvVar{
 						{
 							Name: "NODE_NAME",

--- a/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
+++ b/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
@@ -103,6 +103,9 @@ type KubemarkMachineProviderConfig struct {
 	// TurnUnhealthyPeriodically configures kubemark node to go unready and ready
 	// periodically indefinitely
 	TurnUnhealthyPeriodically bool `json:"turnUnhealthyPeriodically"`
+
+	// Kubemark image with hollow kubelet to run
+	Image string `json:"image"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
So the kubemark docker image is not hard-coded and can be easily changed.