### PR TITLE
Groom manifests

### DIFF
--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -7,9 +7,6 @@ metadata:
     api: clusterapi
     k8s-app: controller
 spec:
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 65534
   selector:
     matchLabels:
       api: clusterapi
@@ -21,6 +18,9 @@ spec:
         api: clusterapi
         k8s-app: controller
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -21,7 +21,6 @@ resources:
 - crds/machine.openshift.io.crd.yaml
 - crds/machineset.openshift.io.crd.yaml
 - crds/machinedeployment.openshift.io.crd.yaml
-- crds/cluster.crd.yaml
 - rbac/rbac_role.yaml
 - rbac/rbac_role_binding.yaml
 - rbac/kubemark_rbac.yaml


### PR DESCRIPTION
- no longer deploy cluster CRD
- move security context  in deployment under the pod spec