### PR TITLE
Allow to specify machine deletion delay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate:
 gendeepcopy:
 	cd ./vendor/k8s.io/code-generator/cmd && go install ./deepcopy-gen
 	deepcopy-gen \
-	  -i ./pkg/apis/kubemarkproviderconfig/v1alpha1/ \
+	  -i ./pkg/apis/kubemarkproviderconfig/v1beta1/ \
 	  -O zz_generated.deepcopy \
 	  -h boilerplate.go.txt
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Currently the kubemark actuator allows to configure the following test scenarios
   image: gofed/kubemark:v1.11.3-6
   ```
 
+Other configuration options:
+- `deletionTimeout` - how much time to wait before a machine gets deleted from the cluster after setting machine deletion timestamp
+
 ## Kubemark
 
 The provided kubemark (through `gofed/kubemark-machine-controllers:d4f6edb`) is slightly updated version of the kubemark.

--- a/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
+++ b/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
@@ -106,6 +106,9 @@ type KubemarkMachineProviderConfig struct {
 
 	// Kubemark image with hollow kubelet to run
 	Image string `json:"image"`
+
+	// Time after which machine gets deleted by the actuator
+	DeletionTimeout *metav1.Duration `json:"deletionTimeout"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubemarkproviderconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubemarkproviderconfig/v1beta1/zz_generated.deepcopy.go
@@ -18,6 +18,7 @@
 package v1beta1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,6 +47,15 @@ func (in *KubemarkMachineProviderConfig) DeepCopyInto(out *KubemarkMachineProvid
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.UnhealthyDuration = in.UnhealthyDuration
 	out.HealthyDuration = in.HealthyDuration
+	if in.DeletionTimeout != nil {
+		in, out := &in.DeletionTimeout, &out.DeletionTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Create a delay before machine is deleted by the actuator. For creating a delay when testing machine health-checker and its integration with disruptive budget controller. I.e. to create a delay before a machine is really deleted to see the MHC ignore such machines when healing cluster. Also, in case of Azure, it takes around 1 minute to delete a machine from the cluster. It causes unexpected timeouts in testing (since machine deletion was supposed to quite fast). Allowing to set the machine deletion timeout can expose corner cases in the test suite itself.

E.g.

```yaml
apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
kind: KubemarkMachineProviderConfig
image: docker.io/gofed/kubemark:v1.13.7-beta.0-1
deletionTimeout: 20s
```