### PR TITLE
Allow to override default kubemark node num cores and memory capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Currently the kubemark actuator allows to configure the following test scenarios
 
 Other configuration options:
 - `deletionTimeout` - how much time to wait before a machine gets deleted from the cluster after setting machine deletion timestamp
+- `numCores` - for a number of cores a kubemark node will report
+- `memoryCapacity` - for memory a kubemark node will report
 
 ## Kubemark
 
@@ -105,7 +107,7 @@ The list of PRs that allow kubemark to force kubelet to have node go Unready and
 **How to build the kubemark image**
 
 1. Clone `k8s.io/kubernetes` repo under `$GOPATH/src/k8s.io/kubernetes`
-1. Checkout to required version (e.g. `$ git checkout v1.11.3`)
+1. Checkout to required version (e.g. `$ git checkout v1.14.3`)
 1. Apply the PRs (and rebase if needed)
 1. Run `make WHAT="cmd/kubemark"`
 1. `$ cp _output/bin/kubemark cluster/images/kubemark/`
@@ -115,8 +117,7 @@ The list of PRs that allow kubemark to force kubelet to have node go Unready and
 
 **Available kubemark images**
 
-* `docker.io/gofed/kubemark:v1.14.3-beta.0-1`
-* `docker.io/gofed/kubemark:v1.13.7-beta.0-1`
-* `docker.io/gofed/kubemark:v1.11.3-6`
+* `docker.io/gofed/kubemark:v1.14.3-beta.0-2`
+* `docker.io/gofed/kubemark:v1.13.7-beta.0-2`
 
 Set through `image` of  `KubemarkMachineProviderConfig`.

--- a/examples/machine-set-2a.yaml
+++ b/examples/machine-set-2a.yaml
@@ -24,7 +24,7 @@ spec:
         value:
           apiVersion: kubemarkproviderconfig.k8s.io/v1alpha1
           kind: KubemarkMachineProviderConfig
-          image: docker.io/gofed/kubemark:v1.11.3-6
+          image: docker.io/gofed/kubemark:v1.14.3-beta.0-2
       versions:
         kubelet: 1.10.1
         controlPlane: 1.10.1

--- a/examples/machine.yaml
+++ b/examples/machine.yaml
@@ -15,7 +15,9 @@ spec:
       unhealthyDuration: 5s
       healthyDuration: 5s
       turnUnhealthyPeriodically: true
-      image: docker.io/gofed/kubemark:v1.11.3-6
+      image: docker.io/gofed/kubemark:v1.14.3-beta.0-2
+      numCores: 2
+      memoryCapacity: 10737418240
   versions:
     kubelet: 1.10.1
     controlPlane: 1.10.1

--- a/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
+++ b/pkg/apis/kubemarkproviderconfig/v1beta1/kubemarkmachineproviderconfig_types.go
@@ -109,6 +109,12 @@ type KubemarkMachineProviderConfig struct {
 
 	// Time after which machine gets deleted by the actuator
 	DeletionTimeout *metav1.Duration `json:"deletionTimeout"`
+
+	// NumCores for a number of cores a kubemark node will claim to have
+	NumCores *int `json:"numCores"`
+
+	// NMemoryCapacityumCores for a memory a kubemark node will claim to have
+	MemoryCapacity *uint `json:"memoryCapacity"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubemarkproviderconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubemarkproviderconfig/v1beta1/zz_generated.deepcopy.go
@@ -56,6 +56,24 @@ func (in *KubemarkMachineProviderConfig) DeepCopyInto(out *KubemarkMachineProvid
 			**out = **in
 		}
 	}
+	if in.NumCores != nil {
+		in, out := &in.NumCores, &out.NumCores
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int)
+			**out = **in
+		}
+	}
+	if in.MemoryCapacity != nil {
+		in, out := &in.MemoryCapacity, &out.MemoryCapacity
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(uint)
+			**out = **in
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Right now, every kubemark node has num cores and memory capacity set to
default values (1 core and 4GB). Different scenarios might requires different
number of cores and memory capacity.