### PR TITLE
Revendor openshift/kubernetes-drain to pick drain fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -426,11 +426,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f7646c654e93258958dba300641f8f674d5a9ed015c11119793ba1156e2acbe9"
+  digest = "1:2c84f94e6e7d83196c038fc6acaf714255a4c4298cca508506f275efaf0b5d85"
   name = "github.com/openshift/kubernetes-drain"
   packages = ["."]
   pruneopts = "T"
-  revision = "c2e51be1758efa30d71a4d30dc4e2db86b70a4df"
+  revision = "39bc526208474f53a7b55f02153d215e347c8e15"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/openshift/kubernetes-drain/drain.go
+++ b/vendor/github.com/openshift/kubernetes-drain/drain.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	typedextensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	typedpolicyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 )
 
@@ -238,7 +238,7 @@ func (o *DrainOptions) unreplicatedFilter(pod corev1.Pod) (bool, *warning, *fata
 }
 
 type DaemonSetFilterOptions struct {
-	client typedextensionsv1beta1.ExtensionsV1beta1Interface
+	client typedappsv1.AppsV1Interface
 	force bool
 	ignoreDaemonSets bool
 }
@@ -328,7 +328,7 @@ func getPodsForDeletion(client kubernetes.Interface, node *corev1.Node, options 
 	fs := podStatuses{}
 
 	daemonSetOptions := &DaemonSetFilterOptions{
-		client: client.ExtensionsV1beta1(),
+		client: client.AppsV1(),
 		force: options.Force,
 		ignoreDaemonSets: options.IgnoreDaemonsets,
 	}
@@ -399,7 +399,7 @@ func deleteOrEvictPods(client kubernetes.Interface, pods []corev1.Pod, options *
 	}
 
 	getPodFn := func(namespace, name string) (*corev1.Pod, error) {
-		return client.CoreV1().Pods(options.Namespace).Get(name, metav1.GetOptions{})
+		return client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 	}
 
 	if len(policyGroupVersion) > 0 {


### PR DESCRIPTION
Picking https://github.com/openshift/kubernetes-drain/commit/a411f7e77acd2ce23b44dd66dc86dcd8ad41e5e9

This fix is required to get CI job ci/jenkins/k8s-e2e working on the updated e2e tests in this PR:
https://github.com/openshift/cluster-api-actuator-pkg/pull/97